### PR TITLE
feat: take input to choose epson printer models

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,9 @@
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
-import { NetPrinter, PrinterBrand } from '@tillpos/rn-receipt-printer-utils';
+import {
+  NetPrinter,
+  PrinterBrand,
+  PrinterSeries,
+} from '@tillpos/rn-receipt-printer-utils';
 import { Buffer } from 'buffer';
 import React, { Fragment, useCallback } from 'react';
 
@@ -24,7 +28,8 @@ export default function App() {
             printer.host,
             printer.port,
             buffer,
-            PrinterBrand.EPSON
+            PrinterBrand.EPSON,
+            PrinterSeries.TM_M30
           );
         })
       );

--- a/ios/RNBLEPrinter.m
+++ b/ios/RNBLEPrinter.m
@@ -25,12 +25,32 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(connectAndSend:(NSString *)bdAddress
                   printRawData:(NSString *)text
                   brand:(NSString *)brand
+                  series:(NSString *)series
                   success:(RCTResponseSenderBlock)successCallback
                   fail:(RCTResponseSenderBlock)errorCallback) {
     @try {
+        int number;
+        if ([series isEqual:@"TM_M30"]){
+            number = 1;
+        }
+        else if ([series isEqual:@"TM_M30II"]){
+            number = 21;
+        }
+        else if ([series isEqual:@"TM_U220"]){
+            number = 15;
+        }
+        else if ([series isEqual:@"TM_T82"]){
+            number = 10;
+        }
+        else if ([series isEqual:@"TM_L90"]){
+            number = 17;
+        }
+        else {
+            number = 1;
+        }
         if ([brand  isEqual: @"EPSON"]) {
             BLEPrinterEpsonAdapter *adapter = [BLEPrinterEpsonAdapter alloc];
-            [adapter connectAndSend:bdAddress printRawData:text success:successCallback fail:errorCallback];
+            [adapter connectAndSend:bdAddress printRawData:text epsonModel:number success:successCallback fail:errorCallback];
         }
         else {
             BLEPrinterGenericAdapter *adapter = [BLEPrinterGenericAdapter alloc];

--- a/ios/RNNetPrinter.m
+++ b/ios/RNNetPrinter.m
@@ -49,7 +49,7 @@ RCT_EXPORT_METHOD(connectAndSend:(NSString *)host
         }
         if ([brand  isEqual: @"EPSON"]) {
             NetPrinterEpsonAdapter *adapter = [NetPrinterEpsonAdapter alloc];
-            [adapter connectAndSend:host withPort:port printRawData:text epsonModel:&number success:successCallback fail:errorCallback];
+            [adapter connectAndSend:host withPort:port printRawData:text epsonModel:number success:successCallback fail:errorCallback];
         }
         else {
             NetPrinterGenericAdapter *adapter = [NetPrinterGenericAdapter alloc];

--- a/ios/RNNetPrinter.m
+++ b/ios/RNNetPrinter.m
@@ -24,12 +24,32 @@ RCT_EXPORT_METHOD(connectAndSend:(NSString *)host
                   withPort:(nonnull NSNumber *)port
                   printRawData:(NSString *)text
                   brand:(NSString *)brand
+                  series:(NSString *)series
                   success:(RCTResponseSenderBlock)successCallback
                   fail:(RCTResponseSenderBlock)errorCallback) {
     @try {
+        int number;
+        if ([series isEqual:@"TM_M30"]){
+            number = 1;
+        }
+        else if ([series isEqual:@"TM_M30II"]){
+            number = 21;
+        }
+        else if ([series isEqual:@"TM_U220"]){
+            number = 15;
+        }
+        else if ([series isEqual:@"TM_T82"]){
+            number = 10;
+        }
+        else if ([series isEqual:@"TM_L90"]){
+            number = 17;
+        }
+        else {
+            number = 1;
+        }
         if ([brand  isEqual: @"EPSON"]) {
             NetPrinterEpsonAdapter *adapter = [NetPrinterEpsonAdapter alloc];
-            [adapter connectAndSend:host withPort:port printRawData:text success:successCallback fail:errorCallback];
+            [adapter connectAndSend:host withPort:port printRawData:text epsonModel:&number success:successCallback fail:errorCallback];
         }
         else {
             NetPrinterGenericAdapter *adapter = [NetPrinterGenericAdapter alloc];

--- a/ios/adapters/epson/BLEPrinterEpsonAdapter.h
+++ b/ios/adapters/epson/BLEPrinterEpsonAdapter.h
@@ -20,7 +20,7 @@
 @interface BLEPrinterEpsonAdapter : NSObject {
     Epos2Printer *printer;
 }
-- (void) connectAndSend:(NSString *)bdAddress printRawData:(NSString *)text success:(RCTResponseSenderBlock)successCallback fail:(RCTResponseSenderBlock)errorCallback;
+- (void) connectAndSend:(NSString *)bdAddress printRawData:(NSString *)text epsonModel:(int)modelNumber success:(RCTResponseSenderBlock)successCallback fail:(RCTResponseSenderBlock)errorCallback;
 @end
 
 #endif /* BLEPrinterEpsonAdapter_h */

--- a/ios/adapters/epson/BLEPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/BLEPrinterEpsonAdapter.m
@@ -27,12 +27,13 @@
 
 - (void) connectAndSend:(NSString *)bdAddress
            printRawData:(NSString *)text
+             epsonModel:(int)modelNumber
                 success:(RCTResponseSenderBlock)successCallback
                    fail:(RCTResponseSenderBlock)errorCallback {
     @try {
         int result = EPOS2_SUCCESS;
 
-        printer = [[Epos2Printer alloc] initWithPrinterSeries:1 lang:EPOS2_MODEL_ANK];
+        printer = [[Epos2Printer alloc] initWithPrinterSeries:modelNumber lang:EPOS2_MODEL_ANK];
         [printer setReceiveEventDelegate:self];
 
         NSString* target = [NSString stringWithFormat:@"BT:%@", bdAddress];

--- a/ios/adapters/epson/NetPrinterEpsonAdapter.h
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.h
@@ -11,5 +11,5 @@
 @interface NetPrinterEpsonAdapter : NSObject {
     Epos2Printer *printer;
 }
-- (void) connectAndSend:(NSString *_Nullable)host withPort:(nonnull NSNumber *)port printRawData:(NSString *_Nullable)text success:(RCTResponseSenderBlock _Nullable )successCallback fail:(RCTResponseSenderBlock _Nullable )errorCallback;
+- (void) connectAndSend:(NSString *_Nullable)host withPort:(nonnull NSNumber *)port printRawData:(NSString *_Nullable)text epsonModel:(int)modelNumber success:(RCTResponseSenderBlock _Nullable )successCallback fail:(RCTResponseSenderBlock _Nullable )errorCallback;
 @end

--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -26,11 +26,12 @@
 - (void) connectAndSend:(NSString *)host
                withPort:(nonnull NSNumber *)port
            printRawData:(NSString *)text
+              epsonModel:(int)modelNumber
                 success:(RCTResponseSenderBlock)successCallback
                    fail:(RCTResponseSenderBlock)errorCallback {
     @try {
         int result = EPOS2_SUCCESS;
-        printer = [[Epos2Printer alloc] initWithPrinterSeries:1 lang:EPOS2_MODEL_ANK];
+        printer = [[Epos2Printer alloc] initWithPrinterSeries:modelNumber lang:EPOS2_MODEL_ANK];
         [printer setReceiveEventDelegate:self];
 
         NSString* target = [NSString stringWithFormat:@"TCP:%@", host];

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ export enum PrinterBrand {
   OTHER = 'OTHER',
 }
 
+export declare enum PrinterSeries {
+  TM_M30 = 'TM_M30',
+  TM_M30II = 'TM_M30II',
+  TM_U220 = 'TM_U220',
+  TM_T82 = 'TM_T82',
+  TM_L90 = 'TM_L90',
+}
 export interface PrinterOptions {
   beep?: boolean;
   cut?: boolean;
@@ -20,6 +27,7 @@ export interface PrinterOptions {
 export interface IBasePrinter {
   device_name: string;
   brand?: PrinterBrand;
+  series?: PrinterSeries;
 }
 
 export interface IUSBPrinter extends IBasePrinter {
@@ -83,7 +91,8 @@ export const BLEPrinter = {
   connectAndSend: (
     bdAddress: string,
     data: Buffer,
-    brand: PrinterBrand
+    brand: PrinterBrand,
+    series: PrinterSeries
   ): Promise<IBLEPrinter> => {
     const { promiseOrTimeout, timeoutId } = promiseWithTimeout<IBLEPrinter>(
       new Promise((resolve, reject) =>
@@ -91,6 +100,7 @@ export const BLEPrinter = {
           bdAddress,
           data.toString('base64'),
           brand,
+          series,
           (printer: IBLEPrinter) => resolve(printer),
           (error: Error) => reject(error)
         )
@@ -110,7 +120,8 @@ export const NetPrinter = {
     host: string,
     port: number,
     data: Buffer,
-    brand: PrinterBrand
+    brand: PrinterBrand,
+    series: PrinterSeries
   ): Promise<INetPrinter> => {
     const { promiseOrTimeout, timeoutId } = promiseWithTimeout<INetPrinter>(
       new Promise((resolve, reject) =>
@@ -119,6 +130,7 @@ export const NetPrinter = {
           port,
           data.toString('base64'),
           brand,
+          series,
           (printer: INetPrinter) => resolve(printer),
           (error: Error) => reject(error)
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export enum PrinterBrand {
   OTHER = 'OTHER',
 }
 
-export declare enum PrinterSeries {
+export enum PrinterSeries {
   TM_M30 = 'TM_M30',
   TM_M30II = 'TM_M30II',
   TM_U220 = 'TM_U220',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Epson adapters (Bluetooth and Net) now take in model number for printer initiation for better compatibility. Previously all printers were initated with TM_M30 as the printer model.

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running sample printing app in this repo with different settings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)