### PR TITLE
fix: :bug: concurrence printing issue on pos-app

### DIFF
--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -87,7 +87,7 @@ NSMutableDictionary *printerLocksByIp;
         }
       } while (_retryAttempts < 3);
 
-      long delayInSeconds = 3;
+      long delayInSeconds = 60;
       long startTime = [[NSDate date] timeIntervalSince1970];
       long currTime = [[NSDate date] timeIntervalSince1970];
       while (!_finishedAsyncCall && startTime + delayInSeconds > currTime) {

--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -87,7 +87,7 @@ NSMutableDictionary *printerLocksByIp;
         }
       } while (_retryAttempts < 3);
 
-      long delayInSeconds = 60;
+      long delayInSeconds = 10;
       long startTime = [[NSDate date] timeIntervalSince1970];
       long currTime = [[NSDate date] timeIntervalSince1970];
       while (!_finishedAsyncCall && startTime + delayInSeconds > currTime) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
**Issue**: `long delayInSeconds = 3;` is not enough for printer to handle multiple print requests. the print job come later get failed immediatedly on [line 98](https://github.com/hitz-group/rn-receipt-printer-utils/blob/89c4136b24a74acc520f3ea2b237981deed55f92/ios/adapters/epson/NetPrinterEpsonAdapter.m#L98)
**Solution**: Increase delayInSecond of printing to 10

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)