### PR TITLE
fix: ensure disconnect and dealloc

### DIFF
--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -11,21 +11,25 @@
 #import "EpsonPrinterSDK.h"
 #import <stdlib.h>
 
-@interface NetPrinterEpsonAdapter () <Epos2PtrReceiveDelegate>
+@interface NetPrinterEpsonAdapter () <Epos2PtrReceiveDelegate,
+                                      Epos2ConnectionDelegate>
 - (void)connectAndSendAux:(NSString *_Nullable)host
              printRawData:(NSString *_Nullable)text
                   success:(RCTResponseSenderBlock _Nullable)successCallback
                      fail:(RCTResponseSenderBlock _Nullable)errorCallback
                printerObj:(Epos2Printer *)printer;
-              //  Assuming here printer object will be cleaned up after the function connectAndSendAux is finished
+//  Assuming here printer object will be cleaned up after the function
+//  connectAndSendAux is finished
 @end
 
-NSMutableDictionary *printerLocksByIp;
+static NSMutableDictionary *printerLocksByIp;
+static NSLock *connectionAPIsema;
+
 @implementation NetPrinterEpsonAdapter {
   RCTResponseSenderBlock _successCallback;
   RCTResponseSenderBlock _errorCallback;
   int _retryAttempts;
-  BOOL _finishedAsyncCall;
+  int _finishedAsyncCall;
 }
 
 - (dispatch_queue_t)methodQueue {
@@ -39,84 +43,112 @@ NSMutableDictionary *printerLocksByIp;
                success:(RCTResponseSenderBlock)successCallback
                   fail:(RCTResponseSenderBlock)errorCallback {
 
-  _retryAttempts = 0;
-  _finishedAsyncCall = NO;
-
-  Epos2Printer *printer =
-      [[Epos2Printer alloc] initWithPrinterSeries:modelNumber
-                                             lang:EPOS2_MODEL_ANK];
-  NSString *printerLock;
-// printerLocksByIp object is a global variable, hence its ref address is being used here as the ID
-// for this code block. Any thread calling this code block of this ID, will lock, or wait until other
-// the lock of printerLocksByIp is released.
-  @synchronized(printerLocksByIp) {
+  _retryAttempts = 3; // TEMP CHANGE NO RETRIES
+  _finishedAsyncCall = 0;
+  @autoreleasepool {
+    Epos2Printer *printer =
+        [[Epos2Printer alloc] initWithPrinterSeries:modelNumber
+                                               lang:EPOS2_MODEL_ANK];
+    NSString *printerLock;
+    // printerLocksByIp object is a global variable, hence its ref address is
+    // being used here as the ID for this code block. Any thread calling this
+    // code block of this ID, will lock, or wait until other the lock of
+    // printerLocksByIp is released.
     if (printerLocksByIp == nil) {
-      printerLocksByIp = [[NSMutableDictionary alloc] init];
-    }
-  }
-
-  @synchronized(printerLocksByIp) {
-    printerLock = [printerLocksByIp objectForKey:host];
-    if (printerLock == nil) {
-      printerLock = [NSString stringWithFormat:@"%@", host];
-      [printerLocksByIp setObject:printerLock forKey:host];
-    }
-  }
-
-  @synchronized(printerLock) {
-    @try {
-      __weak NetPrinterEpsonAdapter *weakSelf = self;
-      [printer setReceiveEventDelegate:weakSelf];
-      do {
-        @try {
-          _retryAttempts++;
-          [self connectAndSendAux:host
-                     printRawData:text
-                          success:successCallback
-                             fail:errorCallback
-                       printerObj:printer];
-          _retryAttempts = 3;
-        } @catch (NSException *exception) {
-          if (_retryAttempts >= 3) {
-            @throw exception;
-          }
-          [printer endTransaction];
-          [printer disconnect];
-          [printer clearCommandBuffer];
-          [NSThread sleepForTimeInterval:(3.0f * _retryAttempts)];
+      @synchronized(printerLocksByIp) {
+        if (printerLocksByIp == nil) {
+          printerLocksByIp = [[NSMutableDictionary alloc] init];
         }
-      } while (_retryAttempts < 3);
-
-      long delayInSeconds = 10;
-      long startTime = [[NSDate date] timeIntervalSince1970];
-      long currTime = [[NSDate date] timeIntervalSince1970];
-      while (!_finishedAsyncCall && startTime + delayInSeconds > currTime) {
-        [NSThread sleepForTimeInterval:0.5];
-        currTime = [[NSDate date] timeIntervalSince1970];
       }
-      if (!_finishedAsyncCall) {
-        [NSException raise:@"Print failed"
-                    format:@"Delegate Function not called"];
-      }
-      // Delegate function onPtrReceive doesn't do the disconnecting anymore,
-      // do the disconnect here if the delegate function executes successfully.
-      // Do the disconnect in the catch if delegate function is not called
-      [printer endTransaction];
-      [printer disconnect];
-      [printer clearCommandBuffer];
-      [printer setReceiveEventDelegate:nil];
-    } @catch (NSException *exception) {
+    }
 
-      [printer endTransaction];
-      int failResult = [printer disconnect];
-      [printer clearCommandBuffer];
-      [printer setReceiveEventDelegate:nil];
-      errorCallback(
-          @[ [NSString stringWithFormat:@"%@ and disconnect code %i",
-                                        exception.reason, failResult] ]);
-    } @finally {
-      _successCallback = nil;
-      _errorCallback = nil;
+    @synchronized(printerLocksByIp) {
+      printerLock = [printerLocksByIp objectForKey:host];
+      if (printerLock == nil) {
+        printerLock = [NSString stringWithFormat:@"%@", host];
+        [printerLocksByIp setObject:printerLock forKey:host];
+      }
+    }
+
+    @synchronized(printerLock) {
+      @try {
+        __weak NetPrinterEpsonAdapter *weakSelf = self;
+        [printer setReceiveEventDelegate:weakSelf];
+        [printer setConnectionEventDelegate:weakSelf];
+        do {
+          @try {
+
+            _retryAttempts++;
+            [self connectAndSendAux:host
+                       printRawData:text
+                            success:successCallback
+                               fail:errorCallback
+                         printerObj:printer];
+            _retryAttempts = 3;
+          } @catch (NSException *exception) {
+            if (_retryAttempts >= 3) {
+              @throw exception;
+            }
+            [printer endTransaction];
+            [self netAdapterDisconnect:printer];
+            [printer clearCommandBuffer];
+            [NSThread sleepForTimeInterval:(3.0f * _retryAttempts)];
+          }
+        } while (_retryAttempts < 3);
+
+        long delayInSeconds = 20;
+        long startTime = [[NSDate date] timeIntervalSince1970];
+        long currTime = [[NSDate date] timeIntervalSince1970];
+
+        while ((_finishedAsyncCall != 1) &&
+               (startTime + delayInSeconds > currTime)) {
+          [NSThread sleepForTimeInterval:0.5];
+          currTime = [[NSDate date] timeIntervalSince1970];
+        }
+        if (!_finishedAsyncCall) {
+          [NSException raise:@"Print failed"
+                      format:@"Delegate Functions not called"];
+        } else if (_finishedAsyncCall == 2) {
+          [NSException
+               raise:@"Print failed"
+              format:@"Disconnect Delegate Function called, epos error"];
+        } else if ((_finishedAsyncCall == 3) || (_finishedAsyncCall == 4)) {
+          while (_finishedAsyncCall == 3) {
+            [NSThread sleepForTimeInterval:0.5];
+          }
+          [NSException raise:@"Print failed"
+                      format:@"reconnection event occurred"];
+        }
+
+        // Delegate function onPtrReceive doesn't do the disconnecting anymore,
+        // do the disconnect here if the delegate function executes
+        // successfully. Do the disconnect in the catch if delegate function is
+        // not called
+        [printer endTransaction];
+        int successDisconnectResult = [self netAdapterDisconnect:printer];
+        while (successDisconnectResult == EPOS2_ERR_PROCESSING) {
+          [NSThread sleepForTimeInterval:0.5];
+          successDisconnectResult = [self netAdapterDisconnect:printer];
+        }
+        [printer clearCommandBuffer];
+        [printer setReceiveEventDelegate:nil];
+      } @catch (NSException *exception) {
+
+        [printer endTransaction];
+        int failResult = [self netAdapterDisconnect:printer];
+        while (failResult == EPOS2_ERR_PROCESSING) {
+          [NSThread sleepForTimeInterval:0.5];
+          failResult = [self netAdapterDisconnect:printer];
+        }
+        [printer clearCommandBuffer];
+        [printer setReceiveEventDelegate:nil];
+        errorCallback(
+            @[ [NSString stringWithFormat:@"%@ and disconnect code %i",
+                                          exception.reason, failResult] ]);
+      } @finally {
+        _successCallback = nil;
+        _errorCallback = nil;
+      }
     }
   }
 }
@@ -128,7 +160,7 @@ NSMutableDictionary *printerLocksByIp;
                printerObj:(Epos2Printer *)printer {
   NSString *target = [NSString stringWithFormat:@"TCP:%@", host];
   int result = EPOS2_SUCCESS;
-  result = [printer connect:target timeout:5000];
+  result = [self netAdapterConnect:printer target:target];
   if (result != EPOS2_SUCCESS) {
 
     [NSException
@@ -149,7 +181,6 @@ NSMutableDictionary *printerLocksByIp;
               status:(Epos2PrinterStatusInfo *)status
           printJobId:(NSString *)printJobId {
   NSString *errMsg = [EpsonUtils makeErrorMessage:status];
-  _finishedAsyncCall = YES;
   if ([errMsg isEqual:@""]) {
     _successCallback != nil ? _successCallback(@[ [NSString
                                   stringWithFormat:@"Successfuly printed"] ])
@@ -160,7 +191,53 @@ NSMutableDictionary *printerLocksByIp;
               stringWithFormat:@"Delegate with ERROR and message %@", errMsg] ])
         : nil;
   }
+  _finishedAsyncCall = 1;
+
   return;
+}
+- (void)onConnection:(id)deviceObj eventType:(int)eventType {
+
+  if (eventType == EPOS2_EVENT_DISCONNECT) {
+    _finishedAsyncCall = 2;
+  } else if (eventType == EPOS2_EVENT_RECONNECTING) {
+    _finishedAsyncCall = 3;
+  } else {
+    _finishedAsyncCall = 4;
+  }
+}
+
+- (int)netAdapterConnect:(Epos2Printer *)printerObj target:(NSString *)target {
+  if (connectionAPIsema == nil) {
+    @synchronized(connectionAPIsema) {
+      if (connectionAPIsema == nil) {
+        connectionAPIsema = [[NSLock alloc] init];
+      }
+    }
+  }
+  [connectionAPIsema lock];
+
+  int result = [printerObj connect:target timeout:5000];
+
+  [connectionAPIsema unlock];
+
+  return result;
+}
+
+- (int)netAdapterDisconnect:(Epos2Printer *)printerObj {
+  if (connectionAPIsema == nil) {
+    @synchronized(connectionAPIsema) {
+      if (connectionAPIsema == nil) {
+        connectionAPIsema = [[NSLock alloc] init];
+      }
+    }
+  }
+  [connectionAPIsema lock];
+
+  int result = [printerObj disconnect];
+
+  [connectionAPIsema unlock];
+
+  return result;
 }
 
 @end

--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -132,6 +132,7 @@ static NSLock *connectionAPIsema;
         }
         [printer clearCommandBuffer];
         [printer setReceiveEventDelegate:nil];
+        [printer setConnectionEventDelegate:nil];
       } @catch (NSException *exception) {
 
         [printer endTransaction];
@@ -142,6 +143,7 @@ static NSLock *connectionAPIsema;
         }
         [printer clearCommandBuffer];
         [printer setReceiveEventDelegate:nil];
+        [printer setConnectionEventDelegate:nil];
         errorCallback(
             @[ [NSString stringWithFormat:@"%@ and disconnect code %i",
                                           exception.reason, failResult] ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tillpos/rn-receipt-printer-utils",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Fork of react-native-printer. A React Native Library to support USB/BLE/Net printer",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. included local auto release pool to release scoped printer reference at the end of connect and send function execution.
2. Utilising mutex locking to ensure only one call to connect and disconnect epson api is being made at any one time.
3. Ensuring disconnect request is fully processed before proceeding.
4. Checking if reconnection event has occurred and only making disconnect call after it is resolved. Throwing exceptions in cases like these for logging.
5. Increased time out to 20 seconds for onPtrReceive wait.

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)