### PR TITLE
fix: using global dictionary to maintain printer instances

### DIFF
--- a/ios/RNNetPrinter.m
+++ b/ios/RNNetPrinter.m
@@ -4,59 +4,63 @@
 //  Created by Till POS on 14/09/21.
 //
 
-
 #import "RNNetPrinter.h"
 #import "adapters/epson/NetPrinterEpsonAdapter.h"
 #import "adapters/generic/NetPrinterGenericAdapter.h"
-#import "utils/NSDataAdditions.h"
 #import "utils/EpsonUtils.h"
+#import "utils/NSDataAdditions.h"
 
 @implementation RNNetPrinter
 
-- (dispatch_queue_t)methodQueue
-{
-    return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
 }
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(connectAndSend:(NSString *)host
-                  withPort:(nonnull NSNumber *)port
-                  printRawData:(NSString *)text
-                  brand:(NSString *)brand
-                  series:(NSString *)series
-                  success:(RCTResponseSenderBlock)successCallback
-                  fail:(RCTResponseSenderBlock)errorCallback) {
+RCT_EXPORT_METHOD(connectAndSend
+                  : (NSString *)host withPort
+                  : (nonnull NSNumber *)port printRawData
+                  : (NSString *)text brand
+                  : (NSString *)brand series
+                  : (NSString *)series success
+                  : (RCTResponseSenderBlock)successCallback fail
+                  : (RCTResponseSenderBlock)errorCallback) {
+  @autoreleasepool {
     @try {
-        int number;
-        if ([series isEqual:@"TM_M30"]){
-            number = 1;
-        }
-        else if ([series isEqual:@"TM_M30II"]){
-            number = 21;
-        }
-        else if ([series isEqual:@"TM_U220"]){
-            number = 15;
-        }
-        else if ([series isEqual:@"TM_T82"]){
-            number = 10;
-        }
-        else if ([series isEqual:@"TM_L90"]){
-            number = 17;
-        }
-        else {
-            number = 1;
-        }
-        if ([brand  isEqual: @"EPSON"]) {
-            NetPrinterEpsonAdapter *adapter = [NetPrinterEpsonAdapter alloc];
-            [adapter connectAndSend:host withPort:port printRawData:text epsonModel:number success:successCallback fail:errorCallback];
-        }
-        else {
-            NetPrinterGenericAdapter *adapter = [NetPrinterGenericAdapter alloc];
-            [adapter connectAndSend:host withPort:port printRawData:text success:successCallback fail:errorCallback];
-        }
+      int number;
+      if ([series isEqual:@"TM_M30"]) {
+        number = 1;
+      } else if ([series isEqual:@"TM_M30II"]) {
+        number = 21;
+      } else if ([series isEqual:@"TM_U220"]) {
+        number = 15;
+      } else if ([series isEqual:@"TM_T82"]) {
+        number = 10;
+      } else if ([series isEqual:@"TM_L90"]) {
+        number = 17;
+      } else {
+        number = 1;
+      }
+      if ([brand isEqual:@"EPSON"]) {
+        NetPrinterEpsonAdapter *adapter = [NetPrinterEpsonAdapter alloc];
+        [adapter connectAndSend:host
+                       withPort:port
+                   printRawData:text
+                     epsonModel:number
+                        success:successCallback
+                           fail:errorCallback];
+      } else {
+        NetPrinterGenericAdapter *adapter = [NetPrinterGenericAdapter alloc];
+        [adapter connectAndSend:host
+                       withPort:port
+                   printRawData:text
+                        success:successCallback
+                           fail:errorCallback];
+      }
     } @catch (NSException *exception) {
-        errorCallback(@[exception.reason]);
+      errorCallback(@[ exception.reason ]);
     }
+  }
 }
 @end

--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -71,7 +71,7 @@ static NSLock *connectionAPIlock;
           NSString *target = [NSString stringWithFormat:@"TCP:%@", host];
           int result = EPOS2_SUCCESS;
           result = [self netAdapterConnect:printer target:target];
-          if (result != EPOS2_SUCCESS) {
+          if ((result != EPOS2_SUCCESS) && (result != EPOS2_ERR_ILLEGAL) ) {
 
             [NSException
                  raise:@"Invalid connection"

--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -13,22 +13,15 @@
 
 @interface NetPrinterEpsonAdapter () <Epos2PtrReceiveDelegate,
                                       Epos2ConnectionDelegate>
-- (void)connectAndSendAux:(NSString *_Nullable)host
-             printRawData:(NSString *_Nullable)text
-                  success:(RCTResponseSenderBlock _Nullable)successCallback
-                     fail:(RCTResponseSenderBlock _Nullable)errorCallback
-               printerObj:(Epos2Printer *)printer;
-//  Assuming here printer object will be cleaned up after the function
-//  connectAndSendAux is finished
+
 @end
 
-static NSMutableDictionary *printerLocksByIp;
-static NSLock *connectionAPIsema;
+static NSMutableDictionary *printersByIP;
+static NSLock *connectionAPIlock;
 
 @implementation NetPrinterEpsonAdapter {
   RCTResponseSenderBlock _successCallback;
   RCTResponseSenderBlock _errorCallback;
-  int _retryAttempts;
   int _finishedAsyncCall;
 }
 
@@ -43,58 +36,56 @@ static NSLock *connectionAPIsema;
                success:(RCTResponseSenderBlock)successCallback
                   fail:(RCTResponseSenderBlock)errorCallback {
 
-  _retryAttempts = 3; // TEMP CHANGE NO RETRIES
   _finishedAsyncCall = 0;
   @autoreleasepool {
-    Epos2Printer *printer =
-        [[Epos2Printer alloc] initWithPrinterSeries:modelNumber
-                                               lang:EPOS2_MODEL_ANK];
-    NSString *printerLock;
-    // printerLocksByIp object is a global variable, hence its ref address is
+    Epos2Printer *printer;
+
+    // printersByIP object is a global variable, hence its ref address is
     // being used here as the ID for this code block. Any thread calling this
     // code block of this ID, will lock, or wait until other the lock of
-    // printerLocksByIp is released.
-    if (printerLocksByIp == nil) {
-      @synchronized(printerLocksByIp) {
-        if (printerLocksByIp == nil) {
-          printerLocksByIp = [[NSMutableDictionary alloc] init];
+    // printersByIP is released.
+    if (printersByIP == nil) {
+      @synchronized(printersByIP) {
+        if (printersByIP == nil) {
+          printersByIP = [[NSMutableDictionary alloc] init];
         }
       }
     }
 
-    @synchronized(printerLocksByIp) {
-      printerLock = [printerLocksByIp objectForKey:host];
-      if (printerLock == nil) {
-        printerLock = [NSString stringWithFormat:@"%@", host];
-        [printerLocksByIp setObject:printerLock forKey:host];
+    @synchronized(printersByIP) {
+      printer = [printersByIP objectForKey:host];
+      if (printer == nil) {
+        printer = [[Epos2Printer alloc] initWithPrinterSeries:modelNumber
+                                                         lang:EPOS2_MODEL_ANK];
+
+        [printersByIP setObject:printer forKey:host];
       }
     }
 
-    @synchronized(printerLock) {
+    @synchronized(printer) {
       @try {
         __weak NetPrinterEpsonAdapter *weakSelf = self;
         [printer setReceiveEventDelegate:weakSelf];
         [printer setConnectionEventDelegate:weakSelf];
-        do {
-          @try {
 
-            _retryAttempts++;
-            [self connectAndSendAux:host
-                       printRawData:text
-                            success:successCallback
-                               fail:errorCallback
-                         printerObj:printer];
-            _retryAttempts = 3;
-          } @catch (NSException *exception) {
-            if (_retryAttempts >= 3) {
-              @throw exception;
-            }
-            [printer endTransaction];
-            [self netAdapterDisconnect:printer];
-            [printer clearCommandBuffer];
-            [NSThread sleepForTimeInterval:(3.0f * _retryAttempts)];
+          NSString *target = [NSString stringWithFormat:@"TCP:%@", host];
+          int result = EPOS2_SUCCESS;
+          result = [self netAdapterConnect:printer target:target];
+          if (result != EPOS2_SUCCESS) {
+
+            [NSException
+                 raise:@"Invalid connection"
+                format:@"Can't connect to printer %@, ERROR code: %i", host, result];
           }
-        } while (_retryAttempts < 3);
+          NSData *payload = [NSData dataWithBase64EncodedString:text];
+          [printer beginTransaction];
+          [printer addCommand:payload];
+          result = [printer sendData:5000];
+          if (result != EPOS2_SUCCESS) {
+            [NSException raise:@"Print failed" format:@"Error occurred while printing"];
+          }
+          _successCallback = successCallback;
+          _errorCallback = errorCallback;
 
         long delayInSeconds = 20;
         long startTime = [[NSDate date] timeIntervalSince1970];
@@ -155,29 +146,6 @@ static NSLock *connectionAPIsema;
   }
 }
 
-- (void)connectAndSendAux:(NSString *)host
-             printRawData:(NSString *)text
-                  success:(RCTResponseSenderBlock)successCallback
-                     fail:(RCTResponseSenderBlock)errorCallback
-               printerObj:(Epos2Printer *)printer {
-  NSString *target = [NSString stringWithFormat:@"TCP:%@", host];
-  int result = EPOS2_SUCCESS;
-  result = [self netAdapterConnect:printer target:target];
-  if (result != EPOS2_SUCCESS) {
-
-    [NSException
-         raise:@"Invalid connection"
-        format:@"Can't connect to printer %@, ERROR code: %i", host, result];
-  }
-  NSData *payload = [NSData dataWithBase64EncodedString:text];
-  [printer addCommand:payload];
-  result = [printer sendData:5000];
-  if (result != EPOS2_SUCCESS) {
-    [NSException raise:@"Print failed" format:@"Error occurred while printing"];
-  }
-  _successCallback = successCallback;
-  _errorCallback = errorCallback;
-}
 - (void)onPtrReceive:(Epos2Printer *)printerObj
                 code:(int)code
               status:(Epos2PrinterStatusInfo *)status
@@ -209,35 +177,35 @@ static NSLock *connectionAPIsema;
 }
 
 - (int)netAdapterConnect:(Epos2Printer *)printerObj target:(NSString *)target {
-  if (connectionAPIsema == nil) {
-    @synchronized(connectionAPIsema) {
-      if (connectionAPIsema == nil) {
-        connectionAPIsema = [[NSLock alloc] init];
+  if (connectionAPIlock == nil) {
+    @synchronized(connectionAPIlock) {
+      if (connectionAPIlock == nil) {
+        connectionAPIlock = [[NSLock alloc] init];
       }
     }
   }
-  [connectionAPIsema lock];
+  [connectionAPIlock lock];
 
   int result = [printerObj connect:target timeout:5000];
 
-  [connectionAPIsema unlock];
+  [connectionAPIlock unlock];
 
   return result;
 }
 
 - (int)netAdapterDisconnect:(Epos2Printer *)printerObj {
-  if (connectionAPIsema == nil) {
-    @synchronized(connectionAPIsema) {
-      if (connectionAPIsema == nil) {
-        connectionAPIsema = [[NSLock alloc] init];
+  if (connectionAPIlock == nil) {
+    @synchronized(connectionAPIlock) {
+      if (connectionAPIlock == nil) {
+        connectionAPIlock = [[NSLock alloc] init];
       }
     }
   }
-  [connectionAPIsema lock];
+  [connectionAPIlock lock];
 
   int result = [printerObj disconnect];
 
-  [connectionAPIsema unlock];
+  [connectionAPIlock unlock];
 
   return result;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tillpos/rn-receipt-printer-utils",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Fork of react-native-printer. A React Native Library to support USB/BLE/Net printer",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change will change to global dictionary to store Epos2printer instances rather than strings for locks. This way the printer instance can always be accessed to disconnect.
## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)