### PR TITLE
Feat/remove retry add global instance

### DIFF
--- a/ios/adapters/epson/NetPrinterEpsonAdapter.m
+++ b/ios/adapters/epson/NetPrinterEpsonAdapter.m
@@ -1,213 +1,97 @@
-
 //
 //  NetPrinterEpsonAdapter.m
 //
 //  Created by Till POS on 14/09/21.
 //
 
+
 #import "NetPrinterEpsonAdapter.h"
-#import "../../utils/EpsonUtils.h"
-#import "../../utils/NSDataAdditions.h"
 #import "EpsonPrinterSDK.h"
-#import <stdlib.h>
+#import "../../utils/NSDataAdditions.h"
+#import "../../utils/EpsonUtils.h"
 
-@interface NetPrinterEpsonAdapter () <Epos2PtrReceiveDelegate,
-                                      Epos2ConnectionDelegate>
-
+@interface NetPrinterEpsonAdapter() <Epos2PtrReceiveDelegate>
 @end
 
 static NSMutableDictionary *printersByIP;
-static NSLock *connectionAPIlock;
 
 @implementation NetPrinterEpsonAdapter {
-  RCTResponseSenderBlock _successCallback;
-  RCTResponseSenderBlock _errorCallback;
-  int _finishedAsyncCall;
+    RCTResponseSenderBlock _successCallback;
+    RCTResponseSenderBlock _errorCallback;
 }
 
-- (dispatch_queue_t)methodQueue {
-  return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
 }
 
-- (void)connectAndSend:(NSString *)host
-              withPort:(nonnull NSNumber *)port
-          printRawData:(NSString *)text
-            epsonModel:(int)modelNumber
-               success:(RCTResponseSenderBlock)successCallback
-                  fail:(RCTResponseSenderBlock)errorCallback {
-
-  _finishedAsyncCall = 0;
-  @autoreleasepool {
-    Epos2Printer *printer;
-
-    // printersByIP object is a global variable, hence its ref address is
-    // being used here as the ID for this code block. Any thread calling this
-    // code block of this ID, will lock, or wait until other the lock of
-    // printersByIP is released.
-    if (printersByIP == nil) {
-      @synchronized(printersByIP) {
-        if (printersByIP == nil) {
-          printersByIP = [[NSMutableDictionary alloc] init];
-        }
+- (void) connectAndSend:(NSString *)host
+               withPort:(nonnull NSNumber *)port
+           printRawData:(NSString *)text
+              epsonModel:(int)modelNumber
+                success:(RCTResponseSenderBlock)successCallback
+                   fail:(RCTResponseSenderBlock)errorCallback {
+    @try {
+      if(printersByIP == nil)
+      {
+         printersByIP=[[NSMutableDictionary alloc]init];
       }
-    }
+    
+     Epos2Printer *printer = [printersByIP objectForKey:host];
 
-    @synchronized(printersByIP) {
-      printer = [printersByIP objectForKey:host];
       if (printer == nil) {
         printer = [[Epos2Printer alloc] initWithPrinterSeries:modelNumber
                                                          lang:EPOS2_MODEL_ANK];
-
         [printersByIP setObject:printer forKey:host];
       }
-    }
 
-    @synchronized(printer) {
-      @try {
-        __weak NetPrinterEpsonAdapter *weakSelf = self;
-        [printer setReceiveEventDelegate:weakSelf];
-        [printer setConnectionEventDelegate:weakSelf];
+       Epos2PrinterStatusInfo* status = [printer getStatus];
+    [printer setReceiveEventDelegate:self];
+        int result = EPOS2_SUCCESS;
+        
+        NSString* target = [NSString stringWithFormat:@"TCP:%@", host];
+        result = [printer connect:target timeout:5000];
 
-          NSString *target = [NSString stringWithFormat:@"TCP:%@", host];
-          int result = EPOS2_SUCCESS;
-          result = [self netAdapterConnect:printer target:target];
-          if ((result != EPOS2_SUCCESS) && (result != EPOS2_ERR_ILLEGAL) ) {
+        if (result != EPOS2_SUCCESS && result != EPOS2_ERR_ILLEGAL) {
+            [NSException raise:@"Invalid connection" format:@"Can't connect to printer %@", host];
+        }
 
-            [NSException
-                 raise:@"Invalid connection"
-                format:@"Can't connect to printer %@, ERROR code: %i", host, result];
-          }
-          NSData *payload = [NSData dataWithBase64EncodedString:text];
-          [printer beginTransaction];
-          [printer addCommand:payload];
-          result = [printer sendData:5000];
-          if (result != EPOS2_SUCCESS) {
+        NSData* payload = [NSData dataWithBase64EncodedString:text];
+        [printer addCommand:payload];
+        result = [printer sendData:5000];
+
+        if (result != EPOS2_SUCCESS) {
             [NSException raise:@"Print failed" format:@"Error occurred while printing"];
-          }
-          _successCallback = successCallback;
-          _errorCallback = errorCallback;
-
-        long delayInSeconds = 20;
-        long startTime = [[NSDate date] timeIntervalSince1970];
-        long currTime = [[NSDate date] timeIntervalSince1970];
-
-        while ((_finishedAsyncCall != 1) &&
-               (startTime + delayInSeconds > currTime)) {
-          [NSThread sleepForTimeInterval:0.5];
-          currTime = [[NSDate date] timeIntervalSince1970];
-        }
-        if (!_finishedAsyncCall) {
-          [NSException raise:@"Print failed"
-                      format:@"Delegate Functions not called"];
-        } else if (_finishedAsyncCall == 2) {
-          [NSException
-               raise:@"Print failed"
-              format:@"Disconnect Delegate Function called, epos error"];
-        } else if ((_finishedAsyncCall == 3) || (_finishedAsyncCall == 4)) {
-          while (_finishedAsyncCall == 3) {
-            [NSThread sleepForTimeInterval:0.5];
-          }
-          [NSException raise:@"Print failed"
-                      format:@"reconnection event occurred"];
         }
 
-        // Delegate function onPtrReceive doesn't do the disconnecting anymore,
-        // do the disconnect here if the delegate function executes
-        // successfully. Do the disconnect in the catch if delegate function is
-        // not called
-        [printer endTransaction];
-        int successDisconnectResult = [self netAdapterDisconnect:printer];
-        while (successDisconnectResult == EPOS2_ERR_PROCESSING) {
-          [NSThread sleepForTimeInterval:0.5];
-          successDisconnectResult = [self netAdapterDisconnect:printer];
-        }
-        [printer clearCommandBuffer];
-        [printer setReceiveEventDelegate:nil];
-        [printer setConnectionEventDelegate:nil];
-      } @catch (NSException *exception) {
+        _successCallback = successCallback;
+        _errorCallback = errorCallback;
 
-        [printer endTransaction];
-        int failResult = [self netAdapterDisconnect:printer];
-        while (failResult == EPOS2_ERR_PROCESSING) {
-          [NSThread sleepForTimeInterval:0.5];
-          failResult = [self netAdapterDisconnect:printer];
-        }
-        [printer clearCommandBuffer];
-        [printer setReceiveEventDelegate:nil];
-        [printer setConnectionEventDelegate:nil];
-        errorCallback(
-            @[ [NSString stringWithFormat:@"%@ and disconnect code %i",
-                                          exception.reason, failResult] ]);
-      } @finally {
-        _successCallback = nil;
-        _errorCallback = nil;
-      }
+    } @catch (NSException *exception) {
+        errorCallback(@[exception.reason]);
     }
-  }
 }
 
-- (void)onPtrReceive:(Epos2Printer *)printerObj
-                code:(int)code
-              status:(Epos2PrinterStatusInfo *)status
-          printJobId:(NSString *)printJobId {
-  NSString *errMsg = [EpsonUtils makeErrorMessage:status];
-  if ([errMsg isEqual:@""]) {
-    _successCallback != nil ? _successCallback(@[ [NSString
-                                  stringWithFormat:@"Successfuly printed"] ])
-                            : nil;
-  } else {
-    _errorCallback != nil
-        ? _errorCallback(@[ [NSString
-              stringWithFormat:@"Delegate with ERROR and message %@", errMsg] ])
-        : nil;
-  }
-  _finishedAsyncCall = 1;
-
-  return;
-}
-- (void)onConnection:(id)deviceObj eventType:(int)eventType {
-
-  if (eventType == EPOS2_EVENT_DISCONNECT) {
-    _finishedAsyncCall = 2;
-  } else if (eventType == EPOS2_EVENT_RECONNECTING) {
-    _finishedAsyncCall = 3;
-  } else {
-    _finishedAsyncCall = 4;
-  }
-}
-
-- (int)netAdapterConnect:(Epos2Printer *)printerObj target:(NSString *)target {
-  if (connectionAPIlock == nil) {
-    @synchronized(connectionAPIlock) {
-      if (connectionAPIlock == nil) {
-        connectionAPIlock = [[NSLock alloc] init];
-      }
+- (void) onPtrReceive:(Epos2Printer *)printerObj code:(int)code status:(Epos2PrinterStatusInfo *)status printJobId:(NSString *)printJobId
+{
+    NSString *errMsg = [EpsonUtils makeErrorMessage:status];
+    if ([errMsg  isEqual: @""]) {
+        _successCallback != nil ? _successCallback(@[[NSString stringWithFormat:@"Successfuly printed"]]) : nil;
+    } else {
+        _errorCallback != nil ? _errorCallback(@[[NSString stringWithString:errMsg]]) : nil;
     }
-  }
-  [connectionAPIlock lock];
+    _successCallback = nil;
+    _errorCallback = nil;
 
-  int result = [printerObj connect:target timeout:5000];
-
-  [connectionAPIlock unlock];
-
-  return result;
-}
-
-- (int)netAdapterDisconnect:(Epos2Printer *)printerObj {
-  if (connectionAPIlock == nil) {
-    @synchronized(connectionAPIlock) {
-      if (connectionAPIlock == nil) {
-        connectionAPIlock = [[NSLock alloc] init];
-      }
+    [printerObj endTransaction];
+    int failResult = [printerObj disconnect];
+    while (failResult == EPOS2_ERR_PROCESSING) {
+        [NSThread sleepForTimeInterval:0.5];
+        failResult = [self netAdapterDisconnect:printer];
     }
-  }
-  [connectionAPIlock lock];
-
-  int result = [printerObj disconnect];
-
-  [connectionAPIlock unlock];
-
-  return result;
+    [printerObj clearCommandBuffer];
+    [printerObj setReceiveEventDelegate:nil];
+    return;
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tillpos/rn-receipt-printer-utils",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Fork of react-native-printer. A React Native Library to support USB/BLE/Net printer",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Reverted to async structure without connect and send block waiting for delegate callback. No mutex locking. Status check before connection attempt.
## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)